### PR TITLE
Add say test node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cxone-rich-content",
-  "version": "1.1.0",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cxone-rich-content",
-      "version": "1.1.0",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cxone-rich-content",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An example of how you can write a Cognigy.AI 4.0.0 Extension containing Nodes.",
   "main": "build/module.js",
   "scripts": {

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,10 +2,12 @@ import { createExtension } from "@cognigy/extension-tools";
 
 /* import all nodes */
 import { simpleTest } from "./nodes/simpleTest";
+import { sayTest } from "./nodes/sayTest";
 
 export default createExtension({
 	nodes: [
-		simpleTest
+		simpleTest,
+		sayTest
 	],
 
 	connections: []

--- a/src/nodes/sayTest.ts
+++ b/src/nodes/sayTest.ts
@@ -1,0 +1,33 @@
+import { createNodeDescriptor, INodeFunctionBaseParams } from "@cognigy/extension-tools";
+
+/**
+ * Test node with a say field that outputs the configured say message
+ */
+
+export interface ISayTestParams extends INodeFunctionBaseParams {
+	config: {
+		sayConfig: any;
+	};
+}
+
+export const sayTest = createNodeDescriptor({
+	type: "sayTest",
+	defaultLabel: "Say Test Node",
+	fields: [
+		{
+			key: "sayConfig",
+			type: "say",
+			label: "Say Configuration",
+			description: "Configure the output message using the full Say control"
+		}
+	],
+	function: async ({ cognigy, config }: ISayTestParams) => {
+		const { api } = cognigy;
+		const { sayConfig } = config;
+
+		// Output the configured say message
+		if (sayConfig) {
+			api.say(sayConfig);
+		}
+	}
+});


### PR DESCRIPTION
## Summary
- Added sayTest node with full Say control field type
- Node outputs the configured say message as-is

## Changes
- Created sayTest node implementation
- Updated module.ts to export new node
- Bumped version to 0.0.2

## Testing
This PR tests the git flow with a new node type using the "say" field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)