### PR TITLE
Release v0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cxone-rich-content",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cxone-rich-content",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "ISC",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cxone-rich-content",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "An extension for NICE CXone rich content functionality, providing custom nodes for easier dev/build of CXone integrated conversations.",
   "main": "build/module.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Release v0.0.8 - cleanup release removing test node reintroduced during sync.

## Changes Since v0.0.7
- Removed sayTest node that was reintroduced during main→develop sync
- Version bumped to 0.0.8

## Release Artifacts
This release will:
- Create git tag `v0.0.8`
- Generate GitHub release with `cxone-rich-content-0.0.8.tar.gz`
- Automatically deploy to configured Cognigy environments (patch release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)